### PR TITLE
Grooming using features introduced in C++11 and C++14

### DIFF
--- a/include/DcEnums.h
+++ b/include/DcEnums.h
@@ -1,10 +1,9 @@
-#ifndef DC_ENUMS
-#define DC_ENUMS
+#pramga once
 
 // Disaster type enum
 enum disType
 {
-	disQuake = 0,
+	disQuake,
 	disStorm,
 	disVortex,
 	disMeteor,
@@ -14,7 +13,7 @@ enum disType
 // Relative disaster power enum
 enum disPower
 {
-	pwrLow = 0,
+	pwrLow,
 	pwrMedium,
 	pwrHigh,
 	pwrApocalyptic
@@ -23,7 +22,7 @@ enum disPower
 // Disaster targeting method enum
 enum disTarget
 {
-	trgRandom = 0,
+	trgRandom,
 	trgZone,
 	trgPlayer
 };
@@ -32,7 +31,7 @@ enum disTarget
 // Look at the volcano in the top right corner of Plymouth Starship 1 if you don't know what I'm talking about.
 enum disVolcanoDir
 {
-	volSouth = 0,
+	volSouth,
 	volSouthEast,
 	volSouthWest,
 	volNone				// Use this if you don't want to play the volcano animation, for whatever reason.
@@ -41,11 +40,9 @@ enum disVolcanoDir
 // Lava spread speed enum.
 enum disSpeed
 {
-	spdStopped = 0,
+	spdStopped,
 	spdSlow,
 	spdMedium,
 	spdFast,
 	spdInstant
 };
-
-#endif

--- a/include/DcStructs.h
+++ b/include/DcStructs.h
@@ -1,5 +1,4 @@
-#ifndef DC_STRUCTS
-#define DC_STRUCTS
+#pragma once
 
 #include <Outpost2DLL.h>
 
@@ -14,12 +13,10 @@ struct DisasterZone
 struct Volcano
 {
 	LOCATION eruptAt;		  // Location for the eruption to occur
-	int warnTime,			  // Tick that the volcano eruption should start playing.
-		eruptTime;			  // Time of first warning (erupts 10 marks later)
-	bool animStarted,		  // Set once the lava flow animation on the volcano has started playing.
-		 eruptionSet;		  // Set once TethysGame::SetEruption has been called.
-	disVolcanoDir direction;
-	disSpeed speed;
+	int warnTime = 0;			  // Tick that the volcano eruption should start playing.
+	int	eruptTime = 0;			  // Time of first warning (erupts 10 marks later)
+	bool animStarted = false;		  // Set once the lava flow animation on the volcano has started playing.
+	bool eruptionSet = false;		  // Set once TethysGame::SetEruption has been called.
+	disVolcanoDir direction = disVolcanoDir::volNone;
+	disSpeed speed = disSpeed::spdStopped;
 };
-
-#endif

--- a/include/DisasterCreator.h
+++ b/include/DisasterCreator.h
@@ -91,7 +91,7 @@ private:
 
 	// Data
 	int lastTick = 0;			  // Records the last time a disaster was successfully rolled for.
-	int	minWait = 0,			  // Minimum time (in ticks) to wait between disasters
+	int	minWait = 0;			  // Minimum time (in ticks) to wait between disasters
 	int	ignoreMinTimeChance = 0;  // Chance to ignore the minimum wait timer.
 
 	Trigger disCheck;		  // Pointer to callback trigger

--- a/include/DisasterCreator.h
+++ b/include/DisasterCreator.h
@@ -18,8 +18,7 @@
    - Finalized sample level.
 */
 
-#ifndef DISASTERCREATOR
-#define DISASTERCREATOR
+#pragma once
 
 #include <Outpost2DLL.h>
 #include <OP2Helper.h>
@@ -37,102 +36,100 @@ const int MAX_SIZE = 20;			// Maximum number of volcanoes/disaster zones a level
 
 class DisasterCreator
 {
-	public:
-		DisasterCreator();
-		~DisasterCreator();
+public:
+	DisasterCreator();
+	~DisasterCreator();
 
-		// Disaster invocation
-		void RollRandom();
-		void DoDisaster(disType type, disPower power, disTarget target);
+	// Disaster invocation
+	void RollRandom();
+	void DoDisaster(disType type, disPower power, disTarget target);
 
-		// Disaster Creator controls
-		void SetMapSize(int width, int height);											// Required.  Tell DC the map dimensions.
-		void SetMinimumWait(int wait);													// Set the minimum amount of time after a disaster the engine will wait before creating another one.
-		void SetNumPlayers(int numPl);													// Allows level creator to control which players can be targetted by disasters.  Useful for protecting AI players.
-		void EnableDisaster(disType type);												// Allows the specified disaster to happen.  At least one disaster must be enabled.
-		void DisableDisaster(disType type);												// The specified disaster will no longer happen.  Also sets spawn chance to zero.
-		void SetDisasterTypeWeight(disType type, int weight);							// Adjusts the chance of the specified disaster occurring.  At least one must be set.
-		void SetDisasterPowerWeight(disPower power, int weight);						// Adjusts the chance of disasters occuring with the specified power.  At least one must be set.
-		void SetDisasterTargetWeight(disTarget target, int weight);						// Adjusts the chance of disasters using the specified targetting type.  At least one must be set.
-		void SetIgnoreChance(int weight);												// Adjusts the chance of disasters ignoring the minimum wait time before spawning.
-		void AddDisasterZone(disType type, MAP_RECT zone);								// Defines a disaster spawn zone.
-		Trigger SetCallbackTrigger(char const *callback, int Delay);					// Creates a time trigger, using the specified delay and callback function.
-		Trigger SetCallbackTrigger(char const *callback, int minDelay, int maxDelay);	// Creates a time trigger, using the specified delay and callback function.
+	// Disaster Creator controls
+	void SetMapSize(int width, int height);											// Required.  Tell DC the map dimensions.
+	void SetMinimumWait(int wait);													// Set the minimum amount of time after a disaster the engine will wait before creating another one.
+	void SetNumPlayers(int numPl);													// Allows level creator to control which players can be targetted by disasters.  Useful for protecting AI players.
+	void EnableDisaster(disType type);												// Allows the specified disaster to happen.  At least one disaster must be enabled.
+	void DisableDisaster(disType type);												// The specified disaster will no longer happen.  Also sets spawn chance to zero.
+	void SetDisasterTypeWeight(disType type, int weight);							// Adjusts the chance of the specified disaster occurring.  At least one must be set.
+	void SetDisasterPowerWeight(disPower power, int weight);						// Adjusts the chance of disasters occuring with the specified power.  At least one must be set.
+	void SetDisasterTargetWeight(disTarget target, int weight);						// Adjusts the chance of disasters using the specified targetting type.  At least one must be set.
+	void SetIgnoreChance(int weight);												// Adjusts the chance of disasters ignoring the minimum wait time before spawning.
+	void AddDisasterZone(disType type, MAP_RECT zone);								// Defines a disaster spawn zone.
+	Trigger SetCallbackTrigger(char const *callback, int Delay);					// Creates a time trigger, using the specified delay and callback function.
+	Trigger SetCallbackTrigger(char const *callback, int minDelay, int maxDelay);	// Creates a time trigger, using the specified delay and callback function.
 
-		// Volcano controls
-		void CheckVolcanoes();
-		void DefineVolcano(LOCATION volcLoc, int lavaAnimTime, int eruptTime, disVolcanoDir dir, disSpeed speed);
-		void SetLavaTiles();
-		void SetLavaTiles(const vector<CellTypes>& optionalTypes);			// Sets all "black rock" tiles to lava-possible.  Optionally, a list of tile types to check for may also be passed.  If so, only black rock tiles that are also one of those tile types will be set as lava possible.
+	// Volcano controls
+	void CheckVolcanoes();
+	void DefineVolcano(LOCATION volcLoc, int lavaAnimTime, int eruptTime, disVolcanoDir dir, disSpeed speed);
+	void SetLavaTiles();
+	void SetLavaTiles(const vector<CellTypes>& optionalTypes);			// Sets all "black rock" tiles to lava-possible.  Optionally, a list of tile types to check for may also be passed.  If so, only black rock tiles that are also one of those tile types will be set as lava possible.
 
-	private:
-		// Disaster creation functions
-        void DoQuake(disPower power, disTarget target);
-		void DoStorm(disPower power, disTarget target);
-		void DoVortex(disPower power, disTarget target);
-		void DoMeteor(disPower power, disTarget target);
+private:
+	// Disaster creation functions
+	void DoQuake(disPower power, disTarget target);
+	void DoStorm(disPower power, disTarget target);
+	void DoVortex(disPower power, disTarget target);
+	void DoMeteor(disPower power, disTarget target);
 
-		// Volcano helper functions
-		void AnimateVolcano(Volcano *v);
-		void EruptVolcano(Volcano *v);
-		void StopVolcano(Volcano *v);
-		void EraseVolcano(int i);
-		int GetSpreadSpeed(disSpeed speed);
+	// Volcano helper functions
+	void AnimateVolcano(Volcano *v);
+	void EruptVolcano(Volcano *v);
+	void StopVolcano(Volcano *v);
+	void EraseVolcano(int i);
+	int GetSpreadSpeed(disSpeed speed);
 
-		// Disaster targetting
-		LOCATION GetDisasterTarget(disTarget trgType, disType type);
-		LOCATION TargetRandomLocation();
-		LOCATION TargetLocationInZone(disType type);
-		LOCATION TargetPlayer();
-		LOCATION GetVortexDestination(LOCATION source);
-		LOCATION GetStormDestination(LOCATION source);
-		LOCATION TargetWithinRadius(LOCATION target);
+	// Disaster targetting
+	LOCATION GetDisasterTarget(disTarget trgType, disType type);
+	LOCATION TargetRandomLocation();
+	LOCATION TargetLocationInZone(disType type);
+	LOCATION TargetPlayer();
+	LOCATION GetVortexDestination(LOCATION source);
+	LOCATION GetStormDestination(LOCATION source);
+	LOCATION TargetWithinRadius(LOCATION target);
 
-		int ApproxDistance(LOCATION s, LOCATION d);
+	int ApproxDistance(LOCATION s, LOCATION d);
 
-		// Data
-		int lastTick,			  // Records the last time a disaster was successfully rolled for.
-			minWait,			  // Minimum time (in ticks) to wait between disasters
-			ignoreMinTimeChance;  // Chance to ignore the minimum wait timer.
+	// Data
+	int lastTick = 0;			  // Records the last time a disaster was successfully rolled for.
+	int	minWait = 0,			  // Minimum time (in ticks) to wait between disasters
+	int	ignoreMinTimeChance = 0;  // Chance to ignore the minimum wait timer.
 
-		Trigger disCheck;		  // Pointer to callback trigger
+	Trigger disCheck;		  // Pointer to callback trigger
 
-		LOCATION mapSize;		  // Stores x/y size of map
-		int mapXOffset;			  // This will be either +31 (regular maps) or -1 (world maps)
+	LOCATION mapSize;		  // Stores x/y size of map
+	int mapXOffset;			  // This will be either +31 (regular maps) or -1 (world maps)
 
-		int numPlayers;
+	int numPlayers = 0;
 
-		// These let us control which disasters are allowed...
-		bool quakesEnabled,
-			 stormsEnabled,
-			 vortexEnabled,
-			 meteorEnabled;
+	// These let us control which disasters are allowed...
+	bool quakesEnabled = false;
+	bool stormsEnabled = false;
+	bool vortexEnabled = false;
+	bool meteorEnabled = false;
 
-		// ...and how often they get rolled.
-		int quakesWeight,
-			stormsWeight,
-			vortexWeight,
-			meteorWeight,
-			noneWeight;
+	// ...and how often they get rolled.
+	int quakesWeight = 0;
+	int	stormsWeight = 0;
+	int	vortexWeight = 0;
+	int	meteorWeight = 0;
+	int	noneWeight = 0;
 
-		// Weights for disaster power.
-		int lowWeight,
-			mediumWeight,
-			highWeight,
-			apocWeight;
+	// Weights for disaster power.
+	int lowWeight = 0;
+	int	mediumWeight = 0;
+	int	highWeight = 0;
+	int	apocWeight = 0;
 
-		// Weights for disaster targeting type.
-		int randWeight,		// Chance to target a completely random point on the map.
-			zoneWeight,		// Chance to target one of the defined disaster zones.
-			plyrWeight;		// Chance to target a point near a player's base or units
+	// Weights for disaster targeting type.
+	int randWeight = 0;		// Chance to target a completely random point on the map.
+	int 	zoneWeight = 0;	// Chance to target one of the defined disaster zones.
+	int 	plyrWeight = 0;	// Chance to target a point near a player's base or units
 
-		// Disaster zones
-		DisasterZone AllZones[MAX_SIZE];
-		int numZonesDefined;
+	// Disaster zones
+	DisasterZone AllZones[MAX_SIZE];
+	int numZonesDefined = 0;
 
-		// Defined volcanoes
-		Volcano AllVolcanoes[MAX_SIZE];
-		int numVolcanoesDefined;
+	// Defined volcanoes
+	Volcano AllVolcanoes[MAX_SIZE];
+	int numVolcanoesDefined = 0;
 };
-
-#endif

--- a/src/DisasterCreator.cpp
+++ b/src/DisasterCreator.cpp
@@ -7,34 +7,7 @@
 DisasterCreator::DisasterCreator()
 {
 	lastTick = TethysGame::Tick();
-	minWait = 0;
-
 	numPlayers = TethysGame::NoPlayers();
-
-	quakesEnabled = false;
-	stormsEnabled = false;
-	vortexEnabled = false;
-	meteorEnabled = false;
-
-	quakesWeight = 0;
-	stormsWeight = 0;
-	vortexWeight = 0;
-	meteorWeight = 0;
-	noneWeight = 0;
-
-	lowWeight = 0;
-	mediumWeight = 0;
-	highWeight = 0;
-	apocWeight = 0;
-
-	randWeight = 0;
-	zoneWeight = 0;
-	plyrWeight = 0;
-
-	ignoreMinTimeChance = 0;
-
-	numZonesDefined = 0;
-	numVolcanoesDefined = 0;
 }
 
 DisasterCreator::~DisasterCreator()


### PR DESCRIPTION
- Replace include guards with ```#pragma once``` directives -- this is the defacto standard these days and it's more efficient.
- Take advantage of C++11 default initialization versus using a initializer list or as was being done assigning values in the c'tor.